### PR TITLE
Improve interface handling in local mode

### DIFF
--- a/gtests/net/packetdrill/config.c
+++ b/gtests/net/packetdrill/config.c
@@ -63,6 +63,7 @@ enum option_codes {
 	OPT_UDP_ENCAPS,
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 	OPT_TUN_DEV,
+	OPT_PERSISTENT_TUN_DEV,
 #endif
 };
 
@@ -96,6 +97,7 @@ struct option options[] = {
 	{ "udp_encapsulation",	.has_arg = true,  NULL, OPT_UDP_ENCAPS },
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 	{ "tun_dev",		.has_arg = true,  NULL, OPT_TUN_DEV },
+	{ "persistent_tun_dev",	.has_arg = false, NULL, OPT_PERSISTENT_TUN_DEV },
 #endif
 	{ NULL },
 };
@@ -131,6 +133,7 @@ void show_usage(void)
 		"\t[--udp_encapsulation=[sctp,tcp]]\n"
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 		"\t[--tun_dev=<tun_dev_name>]\n"
+		"\t[--persistent_tun_dev]\n"
 #endif
 		"\tscript_path ...\n");
 }
@@ -345,6 +348,20 @@ void finalize_config(struct config *config)
 			die("wire_server_ip not specified\n");
 		}
 	}
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+	if ((config->tun_device == NULL) &&
+	    (config->persistent_tun_device == true)) {
+		die("tun_dev not specified\n");
+	}
+	if ((config->is_wire_client) || (config->is_wire_server)){
+		if (config->tun_device != NULL) {
+			die("tun_dev specified specified\n");
+		}
+		if (config->persistent_tun_device == true) {
+			die("persistent_tun_dev requested\n");
+		}
+	}
+#endif
 }
 
 /* Expect that arg is comma-delimited, allowing for spaces. */
@@ -497,6 +514,9 @@ static void process_option(int opt, char *optarg, struct config *config,
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 	case OPT_TUN_DEV:
 		config->tun_device = strdup(optarg);
+		break;
+	case OPT_PERSISTENT_TUN_DEV:
+		config->persistent_tun_device = true;
 		break;
 #endif
 	default:

--- a/gtests/net/packetdrill/config.c
+++ b/gtests/net/packetdrill/config.c
@@ -61,6 +61,9 @@ enum option_codes {
 	OPT_VERBOSE = 'v',	/* our only single-letter option */
 	OPT_DEBUG,
 	OPT_UDP_ENCAPS,
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+	OPT_TUN_DEV,
+#endif
 };
 
 /* Specification of command line options for getopt_long(). */
@@ -91,6 +94,9 @@ struct option options[] = {
 	{ "verbose",		.has_arg = false, NULL, OPT_VERBOSE },
 	{ "debug",		.has_arg = false, NULL, OPT_DEBUG },
 	{ "udp_encapsulation",	.has_arg = true,  NULL, OPT_UDP_ENCAPS },
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+	{ "tun_dev",		.has_arg = true,  NULL, OPT_TUN_DEV },
+#endif
 	{ NULL },
 };
 
@@ -123,6 +129,9 @@ void show_usage(void)
 		"\t[--verbose|-v]\n"
 		"\t[--debug] * requires compilation with DEBUG *\n"
 		"\t[--udp_encapsulation=[sctp,tcp]]\n"
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+		"\t[--tun_dev=<tun_dev_name>]\n"
+#endif
 		"\tscript_path ...\n");
 }
 
@@ -485,6 +494,11 @@ static void process_option(int opt, char *optarg, struct config *config,
 		else
 			die("%s: bad --udp_encapsulation: %s\n", where, optarg);
 		break;
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+	case OPT_TUN_DEV:
+		config->tun_device = strdup(optarg);
+		break;
+#endif
 	default:
 		show_usage();
 		exit(EXIT_FAILURE);

--- a/gtests/net/packetdrill/config.h
+++ b/gtests/net/packetdrill/config.h
@@ -110,6 +110,7 @@ struct config {
 	/* For local testing using a tun interface. */
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 	char *tun_device;
+	bool persistent_tun_device;
 #endif
 };
 

--- a/gtests/net/packetdrill/config.h
+++ b/gtests/net/packetdrill/config.h
@@ -106,6 +106,11 @@ struct config {
 	struct ip_address wire_server_ip;  /* IP of on-the-wire server */
 	char *wire_server_ip_string;	   /* malloc-ed server IP string */
 	u16 wire_server_port;		   /* the port the server listens on */
+
+	/* For local testing using a tun interface. */
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+	char *tun_device;
+#endif
 };
 
 /* Top-level info about the invocation of a test script */

--- a/gtests/net/packetdrill/platforms.h
+++ b/gtests/net/packetdrill/platforms.h
@@ -38,7 +38,7 @@
 #include <netinet/sctp.h>
 #define HAVE_OPEN_MEMSTREAM     1
 #define HAVE_FMEMOPEN           1
-#define TUN_PATH                "/dev/net/tun"
+#define TUN_DIR                 "/dev/net"
 #define HAVE_TCP_INFO           1
 
 #endif  /* linux */
@@ -54,8 +54,7 @@
 #include <netinet/udplite.h>
 #endif
 #define USE_LIBPCAP             1
-#define TUN_PATH                "/dev/tun0"
-#define TUN_DEV                 "tun0"
+#define TUN_DIR                 "/dev"
 #define HAVE_TCP_INFO           1
 #if (__FreeBSD_version < 1000000 && __FreeBSD_version > 902000) || __FreeBSD_version > 1000028
 #define HAVE_FMEMOPEN           1
@@ -63,7 +62,7 @@
 #include "fmemopen.h"
 #endif
 #if (__FreeBSD_version > 902000)
-#define HAVE_OPEN_MEMSTREAM	1
+#define HAVE_OPEN_MEMSTREAM     1
 #else
 #include "open_memstream.h"
 #endif
@@ -75,8 +74,7 @@
 #if defined(__OpenBSD__)
 
 #define USE_LIBPCAP             1
-#define TUN_PATH                "/dev/tun0"
-#define TUN_DEV                 "tun0"
+#define TUN_DIR                 "/dev"
 
 #define HAVE_TCP_INFO           0
 
@@ -92,8 +90,7 @@
 #if defined(__NetBSD__)
 
 #define USE_LIBPCAP             1
-#define TUN_PATH                "/dev/tun0"
-#define TUN_DEV                 "tun0"
+#define TUN_DIR                 "/dev"
 
 #define HAVE_TCP_INFO           0
 

--- a/gtests/net/packetdrill/run.c
+++ b/gtests/net/packetdrill/run.c
@@ -513,9 +513,12 @@ static s64 schedule_start_time_usecs(void)
 }
 
 void signal_handler(int signal_number) {
-	if (state != NULL)
+	if (state != NULL) {
 		close_all_sockets(state);
-	
+		if (state->netdev != NULL) {
+			netdev_free(state->netdev);
+		}
+	}
 	die("Handled signal %d\n", signal_number);
 }
 
@@ -524,9 +527,15 @@ void run_script(struct config *config, struct script *script)
 	char *error = NULL;
 	struct netdev *netdev = NULL;
 	struct event *event = NULL;
-	
+
 	if (signal(SIGINT, signal_handler) == SIG_ERR) {
 		die("could not set up signal handler for SIGINT!");
+	}
+	if (signal(SIGTERM, signal_handler) == SIG_ERR) {
+		die("could not set up signal handler for SIGTERM!");
+	}
+	if (signal(SIGHUP, signal_handler) == SIG_ERR) {
+		die("could not set up signal handler for SIGHUP!");
 	}
 
 	DEBUGP("run_script: running script\n");


### PR DESCRIPTION
FreeBSD used in local mode always the `tun0` interface and kept it around when packetdrill terminated.

This patch adds a `--tun_dev` command line option which allows to specify the `tun` interface to be used. If not specified, the next unused `tun` interface will be created and used.
The old version kept the `tun` interface around on *BSD, but not on Linux. For consistency, *BSD now also removes the interface. To get the old behaviour back, specify the `--persistent_tun_dev` command line option. This allows to run for example Wireshark on the `tun` interface and run multiple tests, which I find handy. 

To get the old behaviour, run `packetdrill` with the `--tun_dev=tun0 --persistent_tun_dev` command line options.

This addresses https://github.com/freebsd-net/packetdrill/issues/10.