### PR TITLE
support accept filters in freebsd; support ellipsis for certain setso…

### DIFF
--- a/gtests/net/packetdrill/lexer.l
+++ b/gtests/net/packetdrill/lexer.l
@@ -334,6 +334,7 @@ iov_len				return IOV_LEN;
 headers				return SF_HDTR_HEADERS;
 trailers			return SF_HDTR_TRAILERS;
 [.][.][.]			return ELLIPSIS;
+af_name				return AF_NAME;
 function_set_name		return FUNCTION_SET_NAME;
 pcbcnt				return PCBCNT;
 assoc_id			return ASSOC_ID;

--- a/gtests/net/packetdrill/parser.y
+++ b/gtests/net/packetdrill/parser.y
@@ -531,6 +531,7 @@ static struct tcp_option *new_tcp_fast_open_option(const char *cookie_string,
 %token <reserved> IPV4 IPV6 ICMP SCTP UDP UDPLITE GRE MTU
 %token <reserved> MPLS LABEL TC TTL
 %token <reserved> OPTION
+%token <reserved> AF_NAME
 %token <reserved> FUNCTION_SET_NAME PCBCNT
 %token <reserved> SRTO_ASSOC_ID SRTO_INITIAL SRTO_MAX SRTO_MIN
 %token <reserved> SINIT_NUM_OSTREAMS SINIT_MAX_INSTREAMS SINIT_MAX_ATTEMPTS
@@ -646,6 +647,7 @@ static struct tcp_option *new_tcp_fast_open_option(const char *cookie_string,
 %type <expression> inaddr sockaddr msghdr cmsghdr cmsg_level cmsg_type cmsg_data
 %type <expression> sf_hdtr iovec pollfd opt_revents
 %type <expression> linger l_onoff l_linger
+%type <expression> accept_filter af_name
 %type <expression> tcp_function_set function_set_name pcbcnt
 %type <udp_encaps_info> opt_udp_encaps_info
 %type <sctp_header_spec> sctp_header_spec
@@ -2873,6 +2875,9 @@ expression
 | linger            {
 	$$ = $1;
 }
+| accept_filter     {
+	$$ = $1;
+}
 | tcp_function_set  {
 	$$ = $1;
 }
@@ -3215,6 +3220,13 @@ linger
 }
 ;
 
+af_name
+: AF_NAME '=' STRING {
+	$$ = new_expression(EXPR_STRING);
+	$$->value.string = $3;
+	$$->format = "\"%s\"";
+}
+
 function_set_name
 : FUNCTION_SET_NAME '=' STRING {
 	$$ = new_expression(EXPR_STRING);
@@ -3237,6 +3249,17 @@ pcbcnt
 	$$ = new_expression(EXPR_ELLIPSIS);
 }
 ;
+
+accept_filter
+: '{' af_name '}' {
+#if defined(__FreeBSD__)
+	$$ = new_expression(EXPR_ACCEPT_FILTER);
+	$$->value.accept_filter = calloc(1, sizeof(struct accept_filter_expr));
+	$$->value.accept_filter->af_name = $2;
+#else
+	$$ = NULL;
+#endif
+}
 
 tcp_function_set
 : '{' function_set_name ',' pcbcnt '}' {

--- a/gtests/net/packetdrill/script.c
+++ b/gtests/net/packetdrill/script.c
@@ -70,6 +70,7 @@ struct expression_type_entry expression_type_table[] = {
 	{ EXPR_POLLFD,                      "pollfd"                          },
 #if defined(__FreeBSD__)
 	{ EXPR_SF_HDTR,                     "sf_hdtr"                         },
+	{ EXPR_ACCEPT_FILTER,               "accept_filter"                   },
 	{ EXPR_TCP_FUNCTION_SET,            "tcp_function_set"                },
 #endif
 	{ EXPR_SCTP_RTOINFO,                "sctp_rtoinfo"                    },
@@ -333,6 +334,10 @@ void free_expression(struct expression *expression)
 		free_expression(expression->value.linger->l_linger);
 		break;
 #if defined(__FreeBSD__)
+	case EXPR_ACCEPT_FILTER:
+		assert(expression->value.accept_filter);
+		free_expression(expression->value.accept_filter->af_name);
+		break;
 	case EXPR_TCP_FUNCTION_SET:
 		assert(expression->value.tcp_function_set);
 		free_expression(expression->value.tcp_function_set->function_set_name);
@@ -2768,6 +2773,10 @@ static int evaluate(struct expression *in,
 		       sizeof(in->value.linger));
 		break;
 #if defined(__FreeBSD__)
+	case EXPR_ACCEPT_FILTER:		/* copy as-is */
+		memcpy(&out->value.accept_filter, &in->value.accept_filter,
+		       sizeof(in->value.accept_filter));
+		break;
 	case EXPR_TCP_FUNCTION_SET:		/* copy as-is */
 		memcpy(&out->value.tcp_function_set, &in->value.tcp_function_set,
 		       sizeof(in->value.tcp_function_set));

--- a/gtests/net/packetdrill/script.h
+++ b/gtests/net/packetdrill/script.h
@@ -49,6 +49,7 @@ enum expression_t {
 	EXPR_POLLFD,		  /* expression tree for a pollfd struct */
 #if defined(__FreeBSD__)
 	EXPR_SF_HDTR,		  /* struct sf_hdtr for sendfile */
+	EXPR_ACCEPT_FILTER,	  /* struct accept_filter_arg */
 	EXPR_TCP_FUNCTION_SET,	  /* struct tcp_function_set */
 #endif
 	EXPR_SCTP_RTOINFO,	  /* struct sctp_rtoinfo for SCTP_RTOINFO */
@@ -120,6 +121,7 @@ struct expression {
 		struct pollfd_expr *pollfd;
 #if defined(__FreeBSD__)
 		struct sf_hdtr_expr *sf_hdtr;
+		struct accept_filter_expr *accept_filter;
 		struct tcp_function_set_expr *tcp_function_set;
 #endif
 		struct sctp_rtoinfo_expr *sctp_rtoinfo;
@@ -233,6 +235,10 @@ struct sf_hdtr_expr {
 	struct expression *hdr_cnt;
 	struct expression *trailers;
 	struct expression *trl_cnt;
+};
+
+struct accept_filter_expr {
+	struct expression *af_name;
 };
 
 struct tcp_function_set_expr {

--- a/gtests/net/packetdrill/symbols_freebsd.c
+++ b/gtests/net/packetdrill/symbols_freebsd.c
@@ -376,6 +376,9 @@ struct int_symbol platform_symbols_table[] = {
 #if defined(TCP_FASTOPEN)
 	{ TCP_FASTOPEN,                     "TCP_FASTOPEN"                    },
 #endif
+#if defined(SO_ACCEPTFILTER)
+	{ SO_ACCEPTFILTER,                  "SO_ACCEPTFILTER"                 },
+#endif
 #if defined(TCP_FUNCTION_BLK)
 	{ TCP_FUNCTION_BLK,                 "TCP_FUNCTION_BLK"                },
 #endif


### PR DESCRIPTION
…ckopt optlens

example script command:

+0.000 setsockopt(3, SOL_SOCKET, SO_ACCEPTFILTER, {af_name="dataready"}, ...) = 0