### PR TITLE
On FreeBSD the accept system call might return early.

### DIFF
--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -1896,6 +1896,15 @@ static int run_syscall_accept(struct state *state,
 		}
 #endif /* DEBUG */
 		if ((socket->state == SOCKET_PASSIVE_SYNACK_SENT) ||  /* TFO */
+#if defined(__FreeBSD__)
+		/*
+		 * In FreeBSD the accept system call might return after the
+		 * reception of the SYN segment and before sending the
+		 * SYN-ACK segment to allow the user to provide data when
+		 * using TFO.
+		 */
+		    (socket->state == SOCKET_PASSIVE_PACKET_RECEIVED) ||
+#endif
 		    (socket->state == SOCKET_PASSIVE_SYNACK_ACKED) ||
 		    (socket->state == SOCKET_PASSIVE_COOKIE_ECHO_RECEIVED)) {
 			assert(is_equal_ip(&socket->live.remote.ip, &ip));


### PR DESCRIPTION
When using TFO and the SYN carries user data, the sending of
the SYN-ACK is delayed and accept returns. This allows the
application to provide user data to be put in the SYN-ACK.